### PR TITLE
chore: strict image metadata

### DIFF
--- a/.changeset/chatty-spiders-work.md
+++ b/.changeset/chatty-spiders-work.md
@@ -2,4 +2,4 @@
 "ome-ngff-schema-zod": patch
 ---
 
-chore: stricter metadata
+fix: loosen strictness for "metadata" and "type" in image multiscales since not specified in NGFF spec

--- a/.changeset/chatty-spiders-work.md
+++ b/.changeset/chatty-spiders-work.md
@@ -1,0 +1,5 @@
+---
+"ome-ngff-schema-zod": patch
+---
+
+chore: stricter metadata

--- a/src/0.1.ts
+++ b/src/0.1.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 type PickRequired<T, K extends keyof T> = Required<Pick<T, K>> & Omit<T, K>;
 
+type Multiscales = z.infer<typeof Multiscales>;
 const Multiscales = z.array(
   z.object({
     name: z.string().optional(),
@@ -35,6 +36,7 @@ const Omero = z.object({
   ).optional(),
 });
 
+type ImageSchema = z.infer<typeof ImageSchema>;
 export const ImageSchema = z
   .object({
     multiscales: Multiscales,
@@ -42,17 +44,16 @@ export const ImageSchema = z
   })
   .describe("JSON from OME-NGFF .zattrs");
 
-type StrictImageSchema = {
+type StrictImageSchema = Omit<ImageSchema, "multiscales"> & {
   multiscales: PickRequired<
-    z.infer<typeof Multiscales>[number],
+    Multiscales[number],
     "version" | "name" | "metadata" // | "type"
   >[];
-  omero: z.infer<typeof ImageSchema>["omero"];
 };
 
 export const StrictImageSchema = ImageSchema.refine(
-  (data): data is StrictImageSchema => {
-    return data.multiscales.every((m) => {
+  (val): val is StrictImageSchema => {
+    return val.multiscales.every((m) => {
       return "version" in m && "name" in m && "metadata" in m;
     });
   },

--- a/src/0.1.ts
+++ b/src/0.1.ts
@@ -45,7 +45,7 @@ export const ImageSchema = z
 type StrictImageSchema = {
   multiscales: PickRequired<
     z.infer<typeof Multiscales>[number],
-    "version" | "name"
+    "version" | "name" | "metadata" // | "type"
   >[];
   omero: z.infer<typeof ImageSchema>["omero"];
 };
@@ -53,7 +53,7 @@ type StrictImageSchema = {
 export const StrictImageSchema = ImageSchema.refine(
   (data): data is StrictImageSchema => {
     return data.multiscales.every((m) => {
-      return "version" in m && "name" in m;
+      return "version" in m && "name" in m && "metadata" in m;
     });
   },
 );

--- a/src/0.3.ts
+++ b/src/0.3.ts
@@ -48,7 +48,7 @@ export const ImageSchema = z
 type StrictImageSchema = {
   multiscales: PickRequired<
     z.infer<typeof Multiscales>[number],
-    "version" | "name"
+    "version" | "name" // | "metadata" | "type"
   >[];
   omero: z.infer<typeof ImageSchema>["omero"];
 };

--- a/src/0.3.ts
+++ b/src/0.3.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 type PickRequired<T, K extends keyof T> = Required<Pick<T, K>> & Omit<T, K>;
 
+type Multiscales = z.infer<typeof Multiscales>;
 const Multiscales = z
   .array(
     z.object({
@@ -21,6 +22,7 @@ const Multiscales = z
   .min(1)
   .describe("The multiscale datasets for this image");
 
+type ImageSchema = z.infer<typeof ImageSchema>;
 export const ImageSchema = z
   .object({
     multiscales: Multiscales,
@@ -45,12 +47,11 @@ export const ImageSchema = z
   })
   .describe("JSON from OME-NGFF .zattrs");
 
-type StrictImageSchema = {
+type StrictImageSchema = Omit<ImageSchema, "multiscales"> & {
   multiscales: PickRequired<
-    z.infer<typeof Multiscales>[number],
+    Multiscales[number],
     "version" | "name" // | "metadata" | "type"
   >[];
-  omero: z.infer<typeof ImageSchema>["omero"];
 };
 
 export const StrictImageSchema = ImageSchema.refine(

--- a/src/0.4.ts
+++ b/src/0.4.ts
@@ -301,7 +301,6 @@ export const ImageSchema = z
 type StrictImageSchema = {
   multiscales: PickRequired<
     z.infer<typeof Multiscales.element>,
-    // TODO: required but not actually properties on base schema
     "version" | "name" // | "metadata" | "type"
   >[];
   omero: z.infer<typeof ImageSchema>["omero"];

--- a/src/0.4.ts
+++ b/src/0.4.ts
@@ -254,6 +254,7 @@ const CoordinateTransformations = z.array(CoordinateTransformation)
     }
   });
 
+type Multiscales = z.infer<typeof Multiscales>;
 const Multiscales = z
   .array(
     z.object({
@@ -291,6 +292,7 @@ const Omero = z.object({
   ),
 });
 
+type ImageSchema = z.infer<typeof ImageSchema>;
 export const ImageSchema = z
   .object({
     multiscales: Multiscales,
@@ -298,12 +300,11 @@ export const ImageSchema = z
   })
   .describe("JSON from OME-NGFF .zattrs");
 
-type StrictImageSchema = {
+type StrictImageSchema = Omit<ImageSchema, "multiscales"> & {
   multiscales: PickRequired<
-    z.infer<typeof Multiscales.element>,
+    Multiscales[number],
     "version" | "name" // | "metadata" | "type"
   >[];
-  omero: z.infer<typeof ImageSchema>["omero"];
 };
 
 export const StrictImageSchema = ImageSchema.refine(

--- a/src/latest.ts
+++ b/src/latest.ts
@@ -276,6 +276,7 @@ const Omero = z
     ),
   });
 
+type Multiscales = z.infer<typeof Multiscales>;
 const Multiscales = z
   .array(
     z.object({
@@ -296,6 +297,7 @@ const Multiscales = z
   .min(1)
   .describe("The multiscale datasets for this image");
 
+type ImageSchema = z.infer<typeof ImageSchema>;
 export const ImageSchema = z
   .object({
     multiscales: Multiscales,
@@ -303,12 +305,11 @@ export const ImageSchema = z
   })
   .describe("JSON from OME-NGFF .zattrs");
 
-type StrictImageSchema = {
+type StrictImageSchema = Omit<ImageSchema, "multiscales"> & {
   multiscales: PickRequired<
-    z.infer<typeof Multiscales.element>,
+    Multiscales[number],
     "version" | "name" // | "metadata" | "type"
   >[];
-  omero: z.infer<typeof ImageSchema>["omero"];
 };
 
 export const StrictImageSchema = ImageSchema.refine(

--- a/src/latest.ts
+++ b/src/latest.ts
@@ -308,7 +308,7 @@ export const ImageSchema = z
 type StrictImageSchema = {
   multiscales: PickRequired<
     z.infer<typeof Multiscales.element>,
-    "version" | "name"
+    "version" | "name" // | "metadata" | "type"
   >[];
   omero: z.infer<typeof ImageSchema>["omero"];
 };

--- a/src/latest.ts
+++ b/src/latest.ts
@@ -291,8 +291,6 @@ const Multiscales = z
         .min(1),
       axes: Axes,
       coordinateTransformations: CoordinateTransformations.optional(),
-      type: z.string().optional(),
-      metadata: z.any().optional(),
     }),
   )
   .min(1)
@@ -317,6 +315,7 @@ export const StrictImageSchema = ImageSchema.refine(
   (val): val is StrictImageSchema => {
     return val.multiscales.every((m) => "version" in m && "name" in m);
   },
+  "Missing required 'version' or 'name' fields in multiscales.",
 );
 
 // Label


### PR DESCRIPTION
The `strict_image.schema` for all versions specifies a required `type` and `metadata` field for each multiscale, but these fields are unspecified in **all** the base schemas (except `metadata` in `v0.1`). 

By default, `zod` strips out unrecognized keys during parsing so this means that any `metadata` or `type` are stripped when parsed with our schemas.

```javascript
import * as v04 from "ome-ngff-schema-zod/v04";

let blah: unknown = {
  multiscales: [
    {
      name: "foo",
      version: "0.4",
      type: "bar",
      metadata: { key: "value" },
      axes: [ /* ... */ ],
      datasets: [ /* ... */ ],
    },
  ],
}
```

```typescript
let img_attrs = v04.ImageSchema.parse(blah); // or v04.StrictImageSchema
console.log(img_attrs);
// {
//   multiscales: [
//     {
//       name: "foo",
//       version: "0.4",
//       axes: [ /* ... */ ],
//       datasets: [ /* ... */ ],
//     },
//   ],
// }
```

Since these fields aren't in the spec, then our parsing is technically correct, but maybe this is a bug upstream?

cc: @joshmoore
