### PR TITLE
chore: rename package to zod-ome-ngff

### DIFF
--- a/.changeset/chatty-spiders-work.md
+++ b/.changeset/chatty-spiders-work.md
@@ -1,5 +1,5 @@
 ---
-"ome-ngff-schema-zod": patch
+"zod-ome-ngff": patch
 ---
 
 fix: loosen strictness for "metadata" and "type" in image multiscales since not specified in NGFF spec

--- a/.changeset/metal-eagles-judge.md
+++ b/.changeset/metal-eagles-judge.md
@@ -1,0 +1,5 @@
+---
+"zod-ome-ngff": patch
+---
+
+chore: rename package zod-ome-ngff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,23 @@
-# ome-ngff-schema-zod
+# zod-ome-ngff
 
 ## 0.1.2
 
 ### Patch Changes
 
-- fix: build package in publish script... ([`7a0bafc`](https://github.com/manzt/ome-ngff-schema-zod/commit/7a0bafc9d0e399ee56c686bac3c91c9e7a32346b))
+- fix: build package in publish script... ([`7a0bafc`](https://github.com/manzt/zod-ome-ngff/commit/7a0bafc9d0e399ee56c686bac3c91c9e7a32346b))
 
 ## 0.1.1
 
 ### Patch Changes
 
-- feat: manual refinement of generated zod schemas ([#5](https://github.com/manzt/ome-ngff-schema-zod/pull/5))
+- feat: manual refinement of generated zod schemas ([#5](https://github.com/manzt/zod-ome-ngff/pull/5))
 
 ## 0.1.0
 
 ### Minor Changes
 
-- fix: refinement of complex `axes` and `coordinateTransformations` schema ([#3](https://github.com/manzt/ome-ngff-schema-zod/pull/3))
+- fix: refinement of complex `axes` and `coordinateTransformations` schema ([#3](https://github.com/manzt/zod-ome-ngff/pull/3))
 
 ### Patch Changes
 
-- feat: generate a `latest` export ([`14acb18`](https://github.com/manzt/ome-ngff-schema-zod/commit/14acb186721e6094d64f31999103ec53a4654487))
+- feat: generate a `latest` export ([`14acb18`](https://github.com/manzt/zod-ome-ngff/commit/14acb186721e6094d64f31999103ec53a4654487))

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# ome-ngff-schema-zod
+# zod-ome-ngff
 
-[![Node version](https://img.shields.io/npm/v/ome-ngff-schema-zod.svg)](https://www.npmjs.com/package/ome-ngff-schema-zod)
-![GitHub Actions](https://github.com/manzt/ome-ngff-schema-zod/actions/workflows/ci.yml/badge.svg)
+[![Node version](https://img.shields.io/npm/v/zod-ome-ngff.svg)](https://www.npmjs.com/package/zod-ome-ngff)
+![GitHub Actions](https://github.com/manzt/zod-ome-ngff/actions/workflows/ci.yml/badge.svg)
 
 > **Warning**: here be dragons...
 
@@ -14,14 +14,14 @@ metadata in JavaScript and TypeScript.
 ## install
 
 ```sh
-pnpm install zod ome-ngff-schema-zod
+pnpm install zod zod-ome-ngff
 ```
 
 ## usage
 
 ```typescript
 import { z } from "zod";
-import * as v04 from "ome-ngff-schema-zod/v04";
+import * as v04 from "zod-ome-ngff/v04";
 
 let Attrs = z.union([
   v04.StrictImageSchema,
@@ -70,12 +70,12 @@ if ("plate" in attrs) {
 Validators are exported for `v0.1`, `v0.2`, `v0.3`, and `v0.4` schemas.
 
 ```typescript
-import * as v01 from "ome-ngff-schema-zod/0.1";
-import * as v02 from "ome-ngff-schema-zod/0.2";
-import * as v03 from "ome-ngff-schema-zod/0.3";
-import * as v04 from "ome-ngff-schema-zod/0.4";
+import * as v01 from "zod-ome-ngff/0.1";
+import * as v02 from "zod-ome-ngff/0.2";
+import * as v03 from "zod-ome-ngff/0.3";
+import * as v04 from "zod-ome-ngff/0.4";
 
-import * as schemas from "ome-ngff-schema-zod"; // latest
+import * as schemas from "zod-ome-ngff"; // latest
 ```
 
 ## development

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zod-ome-ngff",
   "description": "zod schemas for OME-NGFF",
-  "version": "0.1.2",
+  "version": "0.1.0",
   "type": "module",
   "author": "Trevor Manz",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ome-ngff-schema-zod",
+  "name": "zod-ome-ngff",
   "description": "zod schemas for OME-NGFF",
   "version": "0.1.2",
   "type": "module",


### PR DESCRIPTION
More consistent naming with other zod packages and `pydantic-ome-ngff`.
